### PR TITLE
feat: add application_name field for session categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ from mongodb_session_manager import create_mongodb_session_manager
 session_manager = create_mongodb_session_manager(
     session_id="customer-12345",
     connection_string="mongodb://user:pass@host:27017/",
-    database_name="my_database"
+    database_name="my_database",
+    application_name="customer-support-bot"  # Optional: categorize sessions by app
 )
 
 # Create agent with session persistence
@@ -63,6 +64,9 @@ response = agent("Hello, can you help me?")
 
 # Sync agent to persist state and metrics
 session_manager.sync_agent(agent)
+
+# Read application name (immutable, set at creation)
+app_name = session_manager.get_application_name()
 
 # Clean up
 session_manager.close()
@@ -87,6 +91,7 @@ async def lifespan(app: FastAPI):
     initialize_global_factory(
         connection_string="mongodb://localhost:27017/",
         database_name="my_database",
+        application_name="my-fastapi-app",  # Default for all sessions
         maxPoolSize=100,
         minPoolSize=10
     )
@@ -147,6 +152,7 @@ Main class extending `RepositorySessionManager` from Strands SDK.
 | `get_metadata_tool()` | Get Strands tool for agent metadata management |
 | `add_feedback(feedback)` | Store user feedback with rating and comment |
 | `get_feedbacks()` | Retrieve all feedback for the session |
+| `get_application_name()` | Get session's application name (read-only, immutable) |
 | `close()` | Close database connections |
 
 #### `MongoDBSessionManagerFactory`
@@ -284,6 +290,7 @@ Sessions are stored as nested documents:
 {
     "_id": "session-id",
     "session_id": "session-id",
+    "application_name": "my-app",
     "created_at": "2024-01-15T09:00:00Z",
     "updated_at": "2024-01-22T14:30:00Z",
     "agents": {

--- a/src/mongodb_session_manager/mongodb_session_factory.py
+++ b/src/mongodb_session_manager/mongodb_session_factory.py
@@ -27,6 +27,7 @@ class MongoDBSessionManagerFactory:
         collection_name: str = "collection_name",
         client: Optional[MongoClient] = None,
         metadata_fields: Optional[List[str]] = None,
+        application_name: Optional[str] = None,
         **client_kwargs: Any,
     ) -> None:
         """Initialize the session manager factory.
@@ -37,11 +38,13 @@ class MongoDBSessionManagerFactory:
             collection_name: Default collection name for sessions
             client: Pre-configured MongoClient (takes precedence over connection_string)
             metadata_fields: List of fields to include in metadata
+            application_name: Default application name for all sessions created by this factory
             **client_kwargs: Additional arguments for MongoClient configuration
         """
         self.database_name = database_name
         self.collection_name = collection_name
         self.metadata_fields = metadata_fields
+        self.application_name = application_name
 
         if client is not None:
             # Use provided client
@@ -67,6 +70,7 @@ class MongoDBSessionManagerFactory:
         database_name: Optional[str] = None,
         collection_name: Optional[str] = None,
         metadata_fields: Optional[List[str]] = None,
+        application_name: Optional[str] = None,
         **kwargs: Any,
     ) -> MongoDBSessionManager:
         """Create a new session manager instance.
@@ -76,6 +80,7 @@ class MongoDBSessionManagerFactory:
             database_name: Override default database name
             collection_name: Override default collection name
             metadata_fields: Override default metadata fields
+            application_name: Override default application name for this session
             **kwargs: Additional arguments for MongoDBSessionManager (including hooks)
 
         Returns:
@@ -84,6 +89,8 @@ class MongoDBSessionManagerFactory:
         db_name = database_name or self.database_name
         coll_name = collection_name or self.collection_name
         meta_fields = metadata_fields or self.metadata_fields
+        # Use provided application_name or fall back to factory default
+        app_name = application_name if application_name is not None else self.application_name
 
         # Create session manager with shared client
         manager = MongoDBSessionManager(
@@ -92,6 +99,7 @@ class MongoDBSessionManagerFactory:
             collection_name=coll_name,
             client=self._client,
             metadata_fields=meta_fields,
+            application_name=app_name,
             **kwargs,
         )
 
@@ -129,6 +137,7 @@ def initialize_global_factory(
     database_name: str = "database_name",
     collection_name: str = "virtualagent_sessions",
     metadata_fields: Optional[List[str]] = None,
+    application_name: Optional[str] = None,
     **client_kwargs: Any,
 ) -> MongoDBSessionManagerFactory:
     """Initialize the global factory instance.
@@ -139,6 +148,8 @@ def initialize_global_factory(
         connection_string: MongoDB connection string
         database_name: Default database name
         collection_name: Default collection name
+        metadata_fields: Default metadata fields to index
+        application_name: Default application name for all sessions
         **client_kwargs: Additional MongoDB client configuration
 
     Returns:
@@ -155,6 +166,7 @@ def initialize_global_factory(
         database_name=database_name,
         collection_name=collection_name,
         metadata_fields=metadata_fields,
+        application_name=application_name,
         **client_kwargs,
     )
 

--- a/src/mongodb_session_manager/mongodb_session_manager.py
+++ b/src/mongodb_session_manager/mongodb_session_manager.py
@@ -104,6 +104,7 @@ class MongoDBSessionManager(RepositorySessionManager):
         metadata_fields: Optional[List[str]] = None,
         metadataHook: Optional[Callable[[Dict[str, Any]], None]] = None,
         feedbackHook: Optional[Callable[[Dict[str, Any]], None]] = None,
+        application_name: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize Itzulbira Session Manager.
@@ -117,6 +118,7 @@ class MongoDBSessionManager(RepositorySessionManager):
             metadata_fields: List of fields to be indexed in the metadata
             metadataHook: Hook to be called when metadata is updated, deleted or retrieved
             feedbackHook: Hook to be called when feedback is added
+            application_name: Application name for session categorization (immutable after creation)
             **kwargs: Additional arguments passed to parent class and MongoClient
         """
         # Extract MongoDB client kwargs
@@ -156,6 +158,7 @@ class MongoDBSessionManager(RepositorySessionManager):
             collection_name=collection_name,
             client=client,
             metadata_fields=metadata_fields,
+            application_name=application_name,
             **mongo_kwargs,
         )
 
@@ -499,6 +502,21 @@ class MongoDBSessionManager(RepositorySessionManager):
         """
         return self.session_repository.get_session_viewer_password(self.session_id)
 
+    def get_application_name(self) -> Optional[str]:
+        """Get the application_name for this session (read-only, immutable).
+
+        The application_name is set at session creation time and cannot be modified.
+
+        Returns:
+            The application name string, or None if session not found or not set
+
+        Example:
+            app_name = session_manager.get_application_name()
+            if app_name:
+                print(f"Application: {app_name}")
+        """
+        return self.session_repository.get_application_name(self.session_id)
+
     def get_agent_config(self, agent_id: str) -> Optional[Dict[str, Any]]:
         """Get configuration (model and system_prompt) for a specific agent.
 
@@ -664,6 +682,7 @@ def create_mongodb_session_manager(
     database_name: str = "database_name",
     collection_name: str = "collection_name",
     client: Optional[MongoClient] = None,
+    application_name: Optional[str] = None,
     **kwargs: Any,
 ) -> MongoDBSessionManager:
     """Create an Itzulbira Session Manager with default settings.
@@ -674,6 +693,7 @@ def create_mongodb_session_manager(
         database_name: Name of the database
         collection_name: Name of the collection for sessions
         client: Optional pre-configured MongoClient to use
+        application_name: Application name for session categorization (immutable after creation)
         **kwargs: Additional arguments passed to MongoDBSessionManager
 
     Returns:
@@ -685,5 +705,6 @@ def create_mongodb_session_manager(
         database_name=database_name,
         collection_name=collection_name,
         client=client,
+        application_name=application_name,
         **kwargs,
     )

--- a/test_application_name.py
+++ b/test_application_name.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Tests for application_name field functionality.
+
+These tests verify that the application_name field:
+- Is stored as a top-level field in the MongoDB document
+- Is immutable (set only at session creation)
+- Is properly indexed
+- Can be retrieved via get_application_name()
+- Works with both direct creation and factory pattern
+"""
+
+import os
+import uuid
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Import the modules to test
+from mongodb_session_manager import (
+    create_mongodb_session_manager,
+    MongoDBSessionManager,
+    MongoDBSessionManagerFactory,
+    initialize_global_factory,
+    get_global_factory,
+    close_global_factory,
+)
+from mongodb_session_manager.mongodb_session_repository import MongoDBSessionRepository
+
+
+class TestApplicationNameRepository:
+    """Test application_name at the repository level."""
+
+    def test_repository_accepts_application_name_parameter(self):
+        """Test that MongoDBSessionRepository accepts application_name parameter."""
+        with patch.object(MongoDBSessionRepository, '_ensure_indexes'):
+            repo = MongoDBSessionRepository(
+                connection_string="mongodb://localhost:27017/",
+                database_name="test_db",
+                collection_name="test_sessions",
+                application_name="test-app"
+            )
+            assert repo.application_name == "test-app"
+            repo.close()
+
+    def test_repository_application_name_defaults_to_none(self):
+        """Test that application_name defaults to None when not provided."""
+        with patch.object(MongoDBSessionRepository, '_ensure_indexes'):
+            repo = MongoDBSessionRepository(
+                connection_string="mongodb://localhost:27017/",
+                database_name="test_db",
+                collection_name="test_sessions"
+            )
+            assert repo.application_name is None
+            repo.close()
+
+
+class TestApplicationNameManager:
+    """Test application_name at the session manager level."""
+
+    @patch('mongodb_session_manager.mongodb_session_manager.MongoDBSessionRepository')
+    def test_manager_accepts_application_name_parameter(self, mock_repo_class):
+        """Test that MongoDBSessionManager accepts application_name parameter."""
+        # Setup mock
+        mock_repo = MagicMock()
+        mock_repo.read_session.return_value = None
+        mock_repo_class.return_value = mock_repo
+
+        MongoDBSessionManager(
+            session_id="test-session",
+            connection_string="mongodb://localhost:27017/",
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="my-bot"
+        )
+
+        # Verify application_name was passed to repository
+        mock_repo_class.assert_called_once()
+        call_kwargs = mock_repo_class.call_args[1]
+        assert call_kwargs["application_name"] == "my-bot"
+
+    @patch('mongodb_session_manager.mongodb_session_manager.MongoDBSessionRepository')
+    def test_create_mongodb_session_manager_accepts_application_name(self, mock_repo_class):
+        """Test that create_mongodb_session_manager accepts application_name."""
+        mock_repo = MagicMock()
+        mock_repo.read_session.return_value = None
+        mock_repo_class.return_value = mock_repo
+
+        create_mongodb_session_manager(
+            session_id="test-session",
+            connection_string="mongodb://localhost:27017/",
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="customer-support"
+        )
+
+        # Verify application_name was passed to repository
+        call_kwargs = mock_repo_class.call_args[1]
+        assert call_kwargs["application_name"] == "customer-support"
+
+
+class TestApplicationNameFactory:
+    """Test application_name with the factory pattern."""
+
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBConnectionPool')
+    def test_factory_accepts_default_application_name(self, mock_pool):
+        """Test that factory accepts default application_name."""
+        mock_pool.initialize.return_value = MagicMock()
+
+        factory = MongoDBSessionManagerFactory(
+            connection_string="mongodb://localhost:27017/",
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="default-app"
+        )
+        assert factory.application_name == "default-app"
+        factory.close()
+
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBSessionManager')
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBConnectionPool')
+    def test_factory_creates_manager_with_default_application_name(self, mock_pool, mock_manager_class):
+        """Test that factory propagates default application_name to managers."""
+        mock_pool.initialize.return_value = MagicMock()
+        mock_manager = MagicMock()
+        mock_manager_class.return_value = mock_manager
+
+        factory = MongoDBSessionManagerFactory(
+            connection_string="mongodb://localhost:27017/",
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="factory-default"
+        )
+
+        factory.create_session_manager(session_id="test-session")
+
+        # Verify application_name was passed to MongoDBSessionManager
+        call_kwargs = mock_manager_class.call_args[1]
+        assert call_kwargs["application_name"] == "factory-default"
+
+        factory.close()
+
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBSessionManager')
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBConnectionPool')
+    def test_factory_allows_override_per_session(self, mock_pool, mock_manager_class):
+        """Test that factory allows overriding application_name per session."""
+        mock_pool.initialize.return_value = MagicMock()
+        mock_manager_class.return_value = MagicMock()
+
+        factory = MongoDBSessionManagerFactory(
+            connection_string="mongodb://localhost:27017/",
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="factory-default"
+        )
+
+        # Create with override
+        factory.create_session_manager(
+            session_id="test-session",
+            application_name="custom-app"
+        )
+        call_kwargs = mock_manager_class.call_args[1]
+        assert call_kwargs["application_name"] == "custom-app"
+
+        # Create without override (should use factory default)
+        factory.create_session_manager(session_id="test-session-2")
+        call_kwargs = mock_manager_class.call_args[1]
+        assert call_kwargs["application_name"] == "factory-default"
+
+        factory.close()
+
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBSessionManager')
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBConnectionPool')
+    def test_factory_override_with_none_uses_default(self, mock_pool, mock_manager_class):
+        """Test that passing None uses factory default."""
+        mock_pool.initialize.return_value = MagicMock()
+        mock_manager_class.return_value = MagicMock()
+
+        factory = MongoDBSessionManagerFactory(
+            connection_string="mongodb://localhost:27017/",
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="factory-default"
+        )
+
+        # Explicit None should NOT override factory default
+        factory.create_session_manager(
+            session_id="test-session",
+            application_name=None
+        )
+        call_kwargs = mock_manager_class.call_args[1]
+        assert call_kwargs["application_name"] == "factory-default"
+
+        factory.close()
+
+
+class TestGlobalFactoryApplicationName:
+    """Test application_name with global factory functions."""
+
+    def teardown_method(self):
+        """Clean up global factory after each test."""
+        try:
+            close_global_factory()
+        except RuntimeError:
+            pass  # Factory not initialized
+
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBConnectionPool')
+    def test_initialize_global_factory_accepts_application_name(self, mock_pool):
+        """Test that initialize_global_factory accepts application_name."""
+        mock_pool.initialize.return_value = MagicMock()
+
+        factory = initialize_global_factory(
+            connection_string="mongodb://localhost:27017/",
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="global-app"
+        )
+
+        assert factory.application_name == "global-app"
+
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBSessionManager')
+    @patch('mongodb_session_manager.mongodb_session_factory.MongoDBConnectionPool')
+    def test_global_factory_propagates_application_name(self, mock_pool, mock_manager_class):
+        """Test that global factory propagates application_name to sessions."""
+        mock_pool.initialize.return_value = MagicMock()
+        mock_manager_class.return_value = MagicMock()
+
+        initialize_global_factory(
+            connection_string="mongodb://localhost:27017/",
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="global-app"
+        )
+
+        get_global_factory().create_session_manager(session_id="test")
+        call_kwargs = mock_manager_class.call_args[1]
+        assert call_kwargs["application_name"] == "global-app"
+
+
+class TestApplicationNameIntegration:
+    """Integration tests requiring a real MongoDB connection.
+
+    These tests require MONGODB_CONNECTION_STRING environment variable.
+    Skip if not available.
+    """
+
+    @pytest.fixture
+    def mongodb_connection(self):
+        """Get MongoDB connection string from environment."""
+        conn_str = os.environ.get("MONGODB_CONNECTION_STRING")
+        if not conn_str:
+            pytest.skip("MONGODB_CONNECTION_STRING not set")
+        return conn_str
+
+    @pytest.fixture
+    def unique_session_id(self):
+        """Generate a unique session ID for each test."""
+        return f"test-app-name-{uuid.uuid4().hex[:8]}"
+
+    def _create_mock_agent(self, agent_id: str = "test-agent"):
+        """Create a properly mocked agent for MongoDB integration tests."""
+        mock_agent = MagicMock()
+        mock_agent.agent_id = agent_id
+        mock_agent.messages = []
+        # These attributes need to be serializable for MongoDB
+        mock_agent.state = MagicMock()
+        mock_agent.state.get.return_value = {}  # Return empty dict, not MagicMock
+        return mock_agent
+
+    def test_application_name_stored_in_document(self, mongodb_connection, unique_session_id):
+        """Test that application_name is stored at document root level."""
+        manager = create_mongodb_session_manager(
+            session_id=unique_session_id,
+            connection_string=mongodb_connection,
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="integration-test-app"
+        )
+
+        try:
+            # The session document is created when the manager is initialized
+            # Query the document directly (session is auto-created)
+            doc = manager.session_repository.collection.find_one(
+                {"_id": unique_session_id}
+            )
+
+            assert doc is not None, "Session document should exist"
+            assert "application_name" in doc, "application_name should be at root level"
+            assert doc["application_name"] == "integration-test-app"
+
+        finally:
+            # Clean up
+            manager.session_repository.collection.delete_one({"_id": unique_session_id})
+            manager.close()
+
+    def test_get_application_name_returns_value(self, mongodb_connection, unique_session_id):
+        """Test that get_application_name() returns the stored value."""
+        manager = create_mongodb_session_manager(
+            session_id=unique_session_id,
+            connection_string=mongodb_connection,
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="readable-app"
+        )
+
+        try:
+            # Test get_application_name()
+            app_name = manager.get_application_name()
+            assert app_name == "readable-app"
+
+        finally:
+            manager.session_repository.collection.delete_one({"_id": unique_session_id})
+            manager.close()
+
+    def test_application_name_none_when_not_set(self, mongodb_connection, unique_session_id):
+        """Test that get_application_name() returns None when not set."""
+        manager = create_mongodb_session_manager(
+            session_id=unique_session_id,
+            connection_string=mongodb_connection,
+            database_name="test_db",
+            collection_name="test_sessions"
+            # No application_name provided
+        )
+
+        try:
+            app_name = manager.get_application_name()
+            assert app_name is None
+
+        finally:
+            manager.session_repository.collection.delete_one({"_id": unique_session_id})
+            manager.close()
+
+    def test_application_name_index_exists(self, mongodb_connection, unique_session_id):
+        """Test that application_name index is created."""
+        manager = create_mongodb_session_manager(
+            session_id=unique_session_id,
+            connection_string=mongodb_connection,
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="index-test-app"
+        )
+
+        try:
+            # Get index info
+            indexes = manager.session_repository.collection.index_information()
+
+            # Check for application_name index
+            has_app_name_index = any(
+                "application_name" in str(idx.get("key", []))
+                for idx in indexes.values()
+            )
+
+            assert has_app_name_index, "application_name index should exist"
+
+        finally:
+            manager.close()
+
+    def test_factory_integration(self, mongodb_connection, unique_session_id):
+        """Test factory pattern with application_name integration."""
+        factory = MongoDBSessionManagerFactory(
+            connection_string=mongodb_connection,
+            database_name="test_db",
+            collection_name="test_sessions",
+            application_name="factory-integration"
+        )
+
+        try:
+            manager = factory.create_session_manager(session_id=unique_session_id)
+
+            # Verify in database
+            doc = manager.session_repository.collection.find_one(
+                {"_id": unique_session_id}
+            )
+            assert doc["application_name"] == "factory-integration"
+
+            # Verify via get_application_name()
+            assert manager.get_application_name() == "factory-integration"
+
+        finally:
+            manager.session_repository.collection.delete_one({"_id": unique_session_id})
+            factory.close()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Closes #8

- Add immutable `application_name` field at document root level to categorize sessions by application
- New parameter in `MongoDBSessionRepository`, `MongoDBSessionManager`, and Factory classes
- Automatic MongoDB index creation for efficient filtering
- `get_application_name()` method for reading the value (read-only)
- Factory pattern support with default and per-session override capability

## MongoDB Schema

```json
{
  "_id": "session-id",
  "session_id": "session-id",
  "application_name": "my-app",  // NEW - top level, immutable
  "session_type": "default",
  ...
}
```

## Usage

```python
# Basic usage
manager = create_mongodb_session_manager(
    session_id="session-123",
    connection_string="mongodb://...",
    application_name="customer-support-bot"
)

# Read application_name (read-only)
app_name = manager.get_application_name()

# With Factory (recommended)
factory = initialize_global_factory(
    connection_string="mongodb://...",
    application_name="customer-support-bot"  # Default for all sessions
)
manager = factory.create_session_manager(session_id)
```

## Test plan

- [x] Unit tests for Repository, Manager, and Factory
- [x] Integration tests with real MongoDB
- [x] All 29 tests passing
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)