### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-01-28
+
+### Added
+- **Application Name Field**: New `application_name` parameter for session categorization
+  - Immutable top-level field in MongoDB documents (set only at session creation)
+  - Automatic index creation for efficient filtering by application
+  - New `get_application_name()` method in `MongoDBSessionManager` (read-only)
+  - Supported in all creation patterns:
+    - `create_mongodb_session_manager(application_name="my-app")`
+    - `MongoDBSessionManager(application_name="my-app")`
+    - `MongoDBSessionManagerFactory(application_name="default-app")` with per-session override
+    - `initialize_global_factory(application_name="my-app")`
+  - New test file: `test_application_name.py` with 15 tests (unit + integration)
+
+### Changed
+- **MongoDB Schema**: Extended document structure with `application_name` field at root level
+  ```json
+  {
+    "_id": "session-id",
+    "session_id": "session-id",
+    "application_name": "my-app",  // NEW
+    "session_type": "default",
+    ...
+  }
+  ```
+
+### Documentation
+- Updated `README.md` with application_name examples
+- Updated `CLAUDE.md` with new schema and usage patterns
+
+### Benefits
+- ✅ **Multi-application Support**: Categorize sessions by application for filtering
+- ✅ **Session Viewer Integration**: Filter sessions by application in UI
+- ✅ **Analytics**: Analyze usage patterns per application
+- ✅ **Backward Compatible**: Existing sessions work with `application_name: null`
+
 ## [0.4.1] - 2025-01-28
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ When releasing, update version in **three places**:
 2. `pyproject.toml` (`version`)
 3. `CHANGELOG.md` (add release entry)
 
-Current version: **0.4.1**
+Current version: **0.5.0**
 
 ## Workflow Rules
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MongoDB Session Manager
 
-[![Version](https://img.shields.io/badge/version-0.4.1-blue.svg)](https://github.com/iguinea/mongodb-session-manager)
+[![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](https://github.com/iguinea/mongodb-session-manager)
 [![Python](https://img.shields.io/badge/python-3.13+-green.svg)](https://python.org)
 
 A MongoDB session manager for [Strands Agents](https://github.com/strands-agents/strands-agents-python) that provides persistent storage for agent conversations and state, with connection pooling optimized for stateless environments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mongodb-session-manager"
-version = "0.4.1"
+version = "0.5.0"
 description = "MongoDB session management for Strands Agents"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/mongodb_session_manager/__init__.py
+++ b/src/mongodb_session_manager/__init__.py
@@ -114,6 +114,6 @@ __all__.extend(
     ]
 )
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 __author__ = "Iñaki Guinea Beristain"
 __author_email__ = "iguinea@gmail.com"


### PR DESCRIPTION
## Summary

Bump version to 0.5.0 for the `application_name` feature release (PR #11).

### Files Updated
- `src/mongodb_session_manager/__init__.py` - `__version__ = "0.5.0"`
- `pyproject.toml` - `version = "0.5.0"`
- `CLAUDE.md` - Current version updated
- `README.md` - Version badge updated
- `CHANGELOG.md` - Added v0.5.0 entry

### Changelog Entry

**v0.5.0** includes:
- New `application_name` parameter for session categorization
- Immutable top-level field in MongoDB documents
- Automatic index creation
- `get_application_name()` method (read-only)
- Support in all creation patterns (direct, factory, global factory)
- 15 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)