### PR TITLE
chore: downgrade minimum Python version to 3.12.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "mongodb-session-manager"
 version = "0.5.0"
 description = "MongoDB session management for Strands Agents"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12.8"
 dependencies = [
     "boto3>=1.42.0",
     "fastapi>=0.128.0",


### PR DESCRIPTION
## Summary
- Lowers `requires-python` from `>=3.13` to `>=3.12.8` in `pyproject.toml`
- No code changes needed — the codebase uses no Python 3.13-specific features
- All dependencies (`strands-agents`, `uvloop`, `pymongo`, etc.) support Python 3.12

## Analysis
Full audit confirmed:
- `datetime.UTC` → introduced in Python 3.11
- PEP 604 union syntax (`X | Y`) → Python 3.10+
- Generic type hints (`list[T]`) → Python 3.9+ (with `__future__` annotations)
- All 6 hook files, session_viewer, tests, and examples reviewed — no incompatibilities

## Test plan
- [ ] Run `uv sync` with Python 3.12.8 and verify dependency resolution
- [ ] Run `uv run pytest test_*.py -v` with Python 3.12.8
- [ ] Verify package builds with `uv build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)